### PR TITLE
Reload CC:T documentation index periodically

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,13 +9,13 @@ import logging
 import os
 import re
 import sys
-from urllib.request import urlopen
 
 import discord
 from discord.ext import commands
 
 import faq_list
 import log
+from cached_request import CachedRequest
 
 log.configure()
 
@@ -25,7 +25,11 @@ bot = commands.Bot( command_prefix='%' )
 starttime = datetime.utcnow()
 faqs = []
 
-cc_methods = None
+# Fetch from tweaked.cc at most once per minute.
+cc_methods = CachedRequest(
+    60, "https://tweaked.cc/index.json",
+    lambda contents: { k.lower(): v for k, v in json.loads(contents).items() }
+)
 
 LOG.info("Starting discord Bot")
 
@@ -72,13 +76,13 @@ async def faq_error( ctx, error ):
         LOG.error("Error processing faq command: %s", error)
         await ctx.send("An unexpected error occurred when processing the command.")
 
-        
 @bot.command(name='doc', aliases=['d', 'docs'])
 async def doc(ctx, *, search):
     """Searches for a function with the current name, and returns its documentation."""
+    methods = await cc_methods.get()
     search_k = search.lower()
-    if search_k in cc_methods:
-        method = cc_methods[search_k]
+    if search_k in methods:
+        method = methods[search_k]
         embed = discord.Embed(title=method['name'], url=method['source'])
         if 'summary' in method: embed.description = method['summary']
         await ctx.send(embed=embed)
@@ -93,7 +97,7 @@ async def doc_error( ctx, error ):
         LOG.error("Error processing doc command: %s", error)
         await ctx.send("An unexpected error occurred when processing the command.")
 
-        
+
 @bot.command( name='about', aliases=[] )
 async def about( ctx ):
     """Shows information about the bot as well as the relevant version numbers, uptime and useful links."""
@@ -105,15 +109,6 @@ async def about( ctx ):
     embed.add_field( name=":new: **Version information**", value="Bot version: `{}`\nDiscord.py version: `{}`\nPython version: `{}`".format( date.fromtimestamp( os.path.getmtime( 'bot.py' ) ), discord.__version__, sys.version.split( ' ' )[0] ), inline=True )
     embed.add_field( name=":up: **Uptime information**", value="Bot started: `{}`\nBot uptime: `{}`".format( starttime.strftime( "%Y-%m-%d %H:%M:%S UTC" ), (datetime.utcnow().replace( microsecond=0 ) - starttime.replace( microsecond=0 )) ), inline=True )
     await ctx.send( embed=embed )
-
-
-LOG.info("Loading CC:T method index.")
-req = urlopen("https://tweaked.cc/index.json")
-contents = req.read()
-req.close()
-
-cc_methods = { k.lower(): v for k, v in json.loads(contents).items() }
-LOG.info("Loaded %d methods.", len(cc_methods))
 
 for faq in faq_list.FAQS:
     try:

--- a/cached_request.py
+++ b/cached_request.py
@@ -1,0 +1,90 @@
+"""
+Provides a mechanism for querying a resource, then caching it for a
+period of time.
+"""
+
+from typing import cast, TypeVar, Generic, Optional, Callable
+from time import monotonic
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
+import asyncio
+import logging
+
+LOG = logging.getLogger("cached_request")
+
+T = TypeVar('T') #pylint: disable=C0103
+
+__all__ = ["CachedResource", "CachedRequest"]
+
+class CachedResource(Generic[T]):
+    """
+    Caches a resource, preserving it for 'n' seconds before re-fetching it.
+    """
+
+    time_to_live: int
+
+    _resource: Optional[T]
+    _in_progress: Optional[asyncio.Task]
+    _expire_at: float
+
+    def __init__(self, ttl: int):
+        self.time_to_live = ttl
+        self._resource = None
+        self._in_progress = None
+        self._expire_at = monotonic()
+
+    async def get(self) -> T:
+        """Get the contents of this cache."""
+        if self._expire_at >= monotonic() and self._resource is not None:
+            return self._resource
+
+        # If we've got a task running already, wait on that.
+        if self._in_progress is not None:
+            return await self._in_progress
+
+        # Otherwise start a new task, wait on it, and then update the state
+        self._in_progress = task = asyncio.create_task(self.fetch())
+        self._resource = result = await task
+        self._in_progress = None
+        self._expire_at = monotonic() + self.time_to_live
+
+        return result
+
+    async def fetch(self) -> T:
+        """Recompute the contents of this cache."""
+        raise NotImplementedError()
+
+class CachedRequest(CachedResource[T]):
+    """
+    A HTTP request which is cached, and evaluates a function on the request body.
+    """
+
+    url: str
+    _etag: Optional[str]
+
+    def __init__(self, ttl: int, url: str, compute: Callable[[str], T]):
+        super().__init__(ttl)
+        self.url = url
+        self.compute: Callable[[str], T] = compute
+        self._etag = None
+
+    async def fetch(self):
+        def get() -> T:
+            LOG.info("Fetching %s", self.url)
+            request = Request(self.url)
+            if self._etag is not None:
+                request.add_header("If-None-Match", self._etag)
+
+            try:
+                with urlopen(request) as response:
+                    self._etag = response.getheader("ETag")
+                    contents = response.read()
+                LOG.info("Finished request")
+                return self.compute(contents)
+            except HTTPError as err:
+                if err.code == 304:
+                    LOG.info("ETag matched, doing nothing")
+                    return cast(T, self._resource)
+                raise err
+
+        return await asyncio.get_event_loop().run_in_executor(None, get)

--- a/poetry.lock
+++ b/poetry.lock
@@ -132,6 +132,30 @@ version = "4.7.5"
 
 [[package]]
 category = "dev"
+description = "Optional static typing for Python"
+name = "mypy"
+optional = false
+python-versions = ">=3.5"
+version = "0.770"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
+[[package]]
+category = "dev"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+name = "mypy-extensions"
+optional = false
+python-versions = "*"
+version = "0.4.3"
+
+[[package]]
+category = "dev"
 description = "python code static checker"
 name = "pylint"
 optional = false
@@ -151,6 +175,22 @@ name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.14.0"
+
+[[package]]
+category = "dev"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typed-ast"
+optional = false
+python-versions = "*"
+version = "1.4.1"
+
+[[package]]
+category = "dev"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.2"
 
 [[package]]
 category = "main"
@@ -181,7 +221,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "eeb26928a86afc1d790682ce16049ea9dd45b0f73909abe344e9031a368e87f2"
+content-hash = "ba1a265d47dec836aa51a2cc1d14777b971b0f0629abdb1814868b6c5833c4d0"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -277,6 +317,26 @@ multidict = [
     {file = "multidict-4.7.5-cp38-cp38-win_amd64.whl", hash = "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969"},
     {file = "multidict-4.7.5.tar.gz", hash = "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e"},
 ]
+mypy = [
+    {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
+    {file = "mypy-0.770-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754"},
+    {file = "mypy-0.770-cp35-cp35m-win_amd64.whl", hash = "sha256:a8ffcd53cb5dfc131850851cc09f1c44689c2812d0beb954d8138d4f5fc17f65"},
+    {file = "mypy-0.770-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:7687f6455ec3ed7649d1ae574136835a4272b65b3ddcf01ab8704ac65616c5ce"},
+    {file = "mypy-0.770-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3beff56b453b6ef94ecb2996bea101a08f1f8a9771d3cbf4988a61e4d9973761"},
+    {file = "mypy-0.770-cp36-cp36m-win_amd64.whl", hash = "sha256:15b948e1302682e3682f11f50208b726a246ab4e6c1b39f9264a8796bb416aa2"},
+    {file = "mypy-0.770-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:b90928f2d9eb2f33162405f32dde9f6dcead63a0971ca8a1b50eb4ca3e35ceb8"},
+    {file = "mypy-0.770-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c56ffe22faa2e51054c5f7a3bc70a370939c2ed4de308c690e7949230c995913"},
+    {file = "mypy-0.770-cp37-cp37m-win_amd64.whl", hash = "sha256:8dfb69fbf9f3aeed18afffb15e319ca7f8da9642336348ddd6cab2713ddcf8f9"},
+    {file = "mypy-0.770-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:219a3116ecd015f8dca7b5d2c366c973509dfb9a8fc97ef044a36e3da66144a1"},
+    {file = "mypy-0.770-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7ec45a70d40ede1ec7ad7f95b3c94c9cf4c186a32f6bacb1795b60abd2f9ef27"},
+    {file = "mypy-0.770-cp38-cp38-win_amd64.whl", hash = "sha256:f91c7ae919bbc3f96cd5e5b2e786b2b108343d1d7972ea130f7de27fdd547cf3"},
+    {file = "mypy-0.770-py3-none-any.whl", hash = "sha256:3b1fc683fb204c6b4403a1ef23f0b1fac8e4477091585e0c8c54cbdf7d7bb164"},
+    {file = "mypy-0.770.tar.gz", hash = "sha256:8a627507ef9b307b46a1fea9513d5c98680ba09591253082b4c48697ba05a4ae"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 pylint = [
     {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
     {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},
@@ -284,6 +344,34 @@ pylint = [
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
+    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
+    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
+    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
+    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
+    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
+    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
+    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
+    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
+    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
+    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 websockets = [
     {file = "websockets-8.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.8"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"
+mypy = "^0.770"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
 - Add a massively over-engineered caching system. If an item was requested within x seconds, we'll reuse it. Otherwise recompute it.

 - Using this system, provide a mechanism for making cached HTTP requests. As well as the above TTL, we also use the [ETag] system to avoid receiving massive responses.

 - We use the above to fetch the CC:T method index at most every 60 seconds.

   This does introduce a small latency, but doesn't appear to more than 0.2-0.5s on my terrible WiFi, so should be much faster when running on your server.

   We may wish to extend or shorten this delay later on - it means method changes should be picked up fairly quickly, though I realise they don't change /that/ often.

[etag]: https://en.wikipedia.org/wiki/HTTP_ETag