### PR TITLE
Add FAQ about pastebin on CC <1.75

### DIFF
--- a/faq_list.py
+++ b/faq_list.py
@@ -6,5 +6,6 @@ FAQS = [
     ("((turtle)? ?(re)?fuel(ing)?)|((turtle.)?getFuelLevel)|((turtle.)?refuel)", "Turtle fuel", "turtle_fuel.md"),
     ("paste(bin)?", "Pastebin", "pastebin.md"),
     ("center(ing)? ?(text)?", "Centering text", "center_write.md"),
-    ("(don('?t) ?)?ask", "Don't ask to ask", "dontask.md")
+    ("(don('?t) ?)?ask", "Don't ask to ask", "dontask.md"),
+    ("paste(bin)?[-_]((pre-?1.8)|(1.7)|(old([-_]version)?))", "Pastebin on old versions of ComputerCraft", "pastebin-pre1.8.md")
 ]

--- a/faqs/pastebin-pre1.8.md
+++ b/faqs/pastebin-pre1.8.md
@@ -1,0 +1,26 @@
+**Pastebin on old versions of ComputerCraft**
+
+Pastebin changed the way files are downloaded a few years ago. This means that old versions of the `pastebin` program (1.75 and lower for Minecraft 1.7.0 or lower) can't download files anymore without a patch.
+
+Here are two methods you can use to fix the `pastebin` program and make it work on old versions of ComputerCraft.
+
+**Using a resource pack (MC 1.6.1 - 1.7.10)** 
+This method fixes the program for all computers (in all worlds on singleplayer), but it requires the server owner to install a resource pack if used for a server. Simply download [this resource pack](https://www.mediafire.com/download/1g4d4oon6zaf6po/CC+Pastebin+Fix.zip) and install it into your `resourcepacks` folder, or into the server's installation directory. Then restart Minecraft and apply the resource pack. After that, the default `pastebin` program should function normally.
+
+**Manually patching the program**
+This method only fixes the program on one computer, and must be run for each computer that needs to be patched, but it doesn't require modifying Minecraft in any way, and works fine on servers. First, copy the default `pastebin` program to the root directory of your computer, and then edit it with these commands:
+```
+copy /rom/programs/http/pastebin /pastebin
+edit /pastebin
+```
+Then go to line 24, and replace this:
+```
+"http://pastebin.com/raw.php?i="..textutils.urlEncode( paste )
+```
+with this:
+```
+"http://pastebin.com/raw/"..textutils.urlEncode( paste )
+```
+After that, you can run the pastebin program at `/pastebin`.
+
+[This information was taken from a post on the ComputerCraft forums.](http://www.computercraft.info/forums2/index.php?/topic/26882-resource-pack-pastebin-fix-for-pre-mc18x-users/)


### PR DESCRIPTION
The `pastebin` program is broken on ComputerCraft <1.75, and many users have asked why it doesn't work. I have added a FAQ entry that tells users how to fix `pastebin` on those older versions.